### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,11 +1,11 @@
-#Buubles - a little unfinished particle game
+# Buubles - a little unfinished particle game
 
-##just fork it
+## just fork it
 
 
 p.s.: i'm currently at lxjs 2012 in lisbabon, talk to me (if you like). also check out <a href="http://git.io/vienna.js">vienna.js</a> (awesome js meetup in vienna with couch surfing opportunity) 
 
-##MIT LICENSE
+## MIT LICENSE
 
 Copyright (c) 2012 Franz Enzenhofer
 

--- a/node_modules/jsdom/node_modules/htmlparser/README.md
+++ b/node_modules/jsdom/node_modules/htmlparser/README.md
@@ -1,19 +1,19 @@
-#NodeHtmlParser
+# NodeHtmlParser
 A forgiving HTML/XML/RSS parser written in JS for both the browser and NodeJS (yes, despite the name it works just fine in any modern browser). The parser can handle streams (chunked data) and supports custom handlers for writing custom DOMs/output.
 
-##Installing
+## Installing
 
 	npm install htmlparser
 
-##Running Tests
+## Running Tests
 
-###Run tests under node:
+### Run tests under node:
 	node runtests.js
 
-###Run tests in browser:
+### Run tests in browser:
 View runtests.html in any browser
 
-##Usage In Node
+## Usage In Node
 
 ```javascript
 var htmlparser = require("htmlparser");
@@ -29,7 +29,7 @@ parser.parseComplete(rawHtml);
 sys.puts(sys.inspect(handler.dom, false, null));
 ```
 
-##Usage In Browser
+## Usage In Browser
 
 ```javascript
 var handler = new Tautologistics.NodeHtmlParser.DefaultHandler(function (error, dom) {
@@ -43,7 +43,7 @@ parser.parseComplete(document.body.innerHTML);
 alert(JSON.stringify(handler.dom, null, 2));
 ```
 
-##Example output
+## Example output
 
 ```javascript
 [ { raw: 'Xyz ', data: 'Xyz ', type: 'text' }
@@ -66,7 +66,7 @@ alert(JSON.stringify(handler.dom, null, 2));
 ]
 ```
 
-##Streaming To Parser
+## Streaming To Parser
 
 ```javascript
 while (...) {
@@ -76,7 +76,7 @@ while (...) {
 parser.done();	
 ```
 
-##Parsing RSS/Atom Feeds
+## Parsing RSS/Atom Feeds
 
 ```javascript
 new htmlparser.RssHandler(function (error, dom) {
@@ -84,9 +84,9 @@ new htmlparser.RssHandler(function (error, dom) {
 });
 ```
 
-##DefaultHandler Options
+## DefaultHandler Options
 
-###Usage
+### Usage
 
 ```javascript
 var handler = new htmlparser.DefaultHandler(
@@ -95,10 +95,10 @@ var handler = new htmlparser.DefaultHandler(
 	);
 ```
 
-###Option: ignoreWhitespace
+### Option: ignoreWhitespace
 Indicates whether the DOM should exclude text nodes that consists solely of whitespace. The default value is "false".
 
-####Example: true
+#### Example: true
 
 The following HTML:
 
@@ -127,7 +127,7 @@ becomes:
 ]
 ```
 
-####Example: false
+#### Example: false
 
 The following HTML:
 
@@ -157,10 +157,10 @@ becomes:
 ]
 ```
 
-###Option: verbose
+### Option: verbose
 Indicates whether to include extra information on each node in the DOM. This information consists of the "raw" attribute (original, unparsed text found between "<" and ">") and the "data" attribute on "tag", "script", and "comment" nodes. The default value is "true". 
 
-####Example: true
+#### Example: true
 The following HTML:
 
 ```html
@@ -180,7 +180,7 @@ becomes:
 ]
 ```
 
-####Example: false
+#### Example: false
 The following HTML:
 
 ```javascript
@@ -198,10 +198,10 @@ becomes:
 ]
 ```
 
-###Option: enforceEmptyTags
+### Option: enforceEmptyTags
 Indicates whether the DOM should prevent children on tags marked as empty in the HTML spec. Typically this should be set to "true" HTML parsing and "false" for XML parsing. The default value is "true".
 
-####Example: true
+#### Example: true
 The following HTML:
 
 ```html
@@ -216,7 +216,7 @@ becomes:
 ]
 ```
 
-####Example: false
+#### Example: false
 The following HTML:
 
 ```html
@@ -235,11 +235,11 @@ becomes:
 ]
 ```
 
-##DomUtils
+## DomUtils
 
-###TBD (see utils_example.js for now)
+### TBD (see utils_example.js for now)
 
-##Related Projects
+## Related Projects
 
 Looking for CSS selectors to search the DOM? Try Node-SoupSelect, a port of SoupSelect to NodeJS: http://github.com/harryf/node-soupselect
 

--- a/node_modules/jsdom/node_modules/htmlparser/pulls/node-htmlparser/README.md
+++ b/node_modules/jsdom/node_modules/htmlparser/pulls/node-htmlparser/README.md
@@ -1,19 +1,19 @@
-#NodeHtmlParser
+# NodeHtmlParser
 A forgiving HTML/XML/RSS parser written in JS for both the browser and NodeJS (yes, despite the name it works just fine in any modern browser). The parser can handle streams (chunked data) and supports custom handlers for writing custom DOMs/output.
 
-##Installing
+## Installing
 
 	npm install htmlparser
 
-##Running Tests
+## Running Tests
 
-###Run tests under node:
+### Run tests under node:
 	node runtests.js
 
-###Run tests in browser:
+### Run tests in browser:
 View runtests.html in any browser
 
-##Usage In Node
+## Usage In Node
 	var htmlparser = require("node-htmlparser");
 	var rawHtml = "Xyz <script language= javascript>var foo = '<<bar>>';< /  script><!--<!-- Waah! -- -->";
 	var handler = new htmlparser.DefaultHandler(function (error, dom) {
@@ -26,7 +26,7 @@ View runtests.html in any browser
 	parser.parseComplete(rawHtml);
 	sys.puts(sys.inspect(handler.dom, false, null));
 
-##Usage In Browser
+## Usage In Browser
 	var handler = new Tautologistics.NodeHtmlParser.DefaultHandler(function (error, dom) {
 		if (error)
 			[...do something for errors...]
@@ -37,7 +37,7 @@ View runtests.html in any browser
 	parser.parseComplete(document.body.innerHTML);
 	alert(JSON.stringify(handler.dom, null, 2));
 
-##Example output
+## Example output
 	[ { raw: 'Xyz ', data: 'Xyz ', type: 'text' }
 	, { raw: 'script language= javascript'
 	  , data: 'script language= javascript'
@@ -57,31 +57,31 @@ View runtests.html in any browser
 	  }
 	]
 
-##Streaming To Parser
+## Streaming To Parser
 	while (...) {
 		...
 		parser.parseChunk(chunk);
 	}
 	parser.done();	
 
-##Parsing RSS/Atom Feeds
+## Parsing RSS/Atom Feeds
 
 	new htmlparser.RssHandler(function (error, dom) {
 		...
 	});
 
-##DefaultHandler Options
+## DefaultHandler Options
 
-###Usage
+### Usage
 	var handler = new htmlparser.DefaultHandler(
 		  function (error) { ... }
 		, { verbose: false, ignoreWhitespace: true }
 		);
 	
-###Option: ignoreWhitespace
+### Option: ignoreWhitespace
 Indicates whether the DOM should exclude text nodes that consists solely of whitespace. The default value is "false".
 
-####Example: true
+#### Example: true
 The following HTML:
 	<font>
 		<br>this is the text
@@ -102,7 +102,7 @@ becomes:
 	  }
 	]
 
-####Example: false
+#### Example: false
 The following HTML:
 	<font>
 		<br>this is the text
@@ -124,10 +124,10 @@ becomes:
 	  }
 	]
 
-###Option: verbose
+### Option: verbose
 Indicates whether to include extra information on each node in the DOM. This information consists of the "raw" attribute (original, unparsed text found between "<" and ">") and the "data" attribute on "tag", "script", and "comment" nodes. The default value is "true". 
 
-####Example: true
+#### Example: true
 The following HTML:
 	<a href="test.html">xxx</a>
 becomes:
@@ -140,7 +140,7 @@ becomes:
 	  }
 	]
 
-####Example: false
+#### Example: false
 The following HTML:
 	<a href="test.html">xxx</a>
 becomes:
@@ -151,10 +151,10 @@ becomes:
 	  }
 	]
 
-###Option: enforceEmptyTags
+### Option: enforceEmptyTags
 Indicates whether the DOM should prevent children on tags marked as empty in the HTML spec. Typically this should be set to "true" HTML parsing and "false" for XML parsing. The default value is "true".
 
-####Example: true
+#### Example: true
 The following HTML:
 	<link>text</link>
 becomes:
@@ -162,7 +162,7 @@ becomes:
 	, { raw: 'text', data: 'text', type: 'text' }
 	]
 
-####Example: false
+#### Example: false
 The following HTML:
 	<link>text</link>
 becomes:
@@ -174,11 +174,11 @@ becomes:
 	  }
 	]
 
-##DomUtils
+## DomUtils
 
-###TBD (see utils_example.js for now)
+### TBD (see utils_example.js for now)
 
-##Related Projects
+## Related Projects
 
 Looking for CSS selectors to search the DOM? Try Node-SoupSelect, a port of SoupSelect to NodeJS: http://github.com/harryf/node-soupselect
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
